### PR TITLE
Parse multi-word PostgreSQL function argument types

### DIFF
--- a/src/main/scala/za/co/absa/ultet/util/parsers/PgFunctionFileParser.scala
+++ b/src/main/scala/za/co/absa/ultet/util/parsers/PgFunctionFileParser.scala
@@ -109,8 +109,8 @@ object PgFunctionFileParser extends GenericFileParser[FunctionFromSource] {
   // 7 - capturing-group #3 - parameters are matched there as a block - \s also covers line-breaks => parsed further later
 
 
-  private val singleParamCapturingRx = """(?i)\s*(IN|OUT)\s+(\w+)\s+(\w+)\s*""".r // used to break up params from ^^
-  //                              1--1   2------2   3---3   4---4
+  private val singleParamCapturingRx = """(?i)\s*(IN|OUT)\s+(\w+)\s+(.+)\s*""".r // used to break up params from ^^
+  //                              1--1   2------2   3--3 4---4
   // 1 - case insensitive matching
   // 2 - capturing-group #1 IN/OUT param
   // 3 - capturing-group #2 for param name

--- a/src/test/scala/za/co/absa/ultet/util/parsers/PgFunctionFileParserTest.scala
+++ b/src/test/scala/za/co/absa/ultet/util/parsers/PgFunctionFileParserTest.scala
@@ -72,6 +72,30 @@ class PgFunctionFileParserTest extends AnyFlatSpec with Matchers {
 
   }
 
+  it should "parse multi-word IN parameter type" in {
+    val functionString =
+      """/* comment here and there **/
+        |-- owner:
+        |     owner_user123
+        |-- database: eXample_db (   )
+        |CREATE or REPLACE FUNCTION my_schema1.public_functionX(
+        |    IN param_name TIMESTAMP WITH TIME ZONE
+        |) RETURNS record AS
+        |$$
+        |-------------------------------------------------------------------------------
+        |--""".stripMargin
+
+    PgFunctionFileParser.parseSource(functionString).head shouldBe FunctionFromSource(
+      fnName = FunctionName("public_functionX"),
+      paramTypes = Seq(FunctionArgumentType("TIMESTAMP WITH TIME ZONE")),
+      owner = UserName("owner_user123"),
+      users = Set.empty,
+      schema = SchemaName("my_schema1"),
+      database = DatabaseName("eXample_db"),
+      sqlBody = functionString
+    )
+  }
+
   it should "parse example function example file" in {
    val testFileUri = getClass.getClassLoader.getResource("public_function_example.sql").toURI
 


### PR DESCRIPTION
## Summary
- allow `PgFunctionFileParser` to capture the full parameter type clause after the parameter name
- add a regression test for `IN param_name TIMESTAMP WITH TIME ZONE`

## Verification
- `git diff --check`

Scala tests were not run locally because this environment does not have Java or sbt installed (`java` and `sbt` are not available on PATH).

Fixes #47